### PR TITLE
Fixed build failure with Xcode 7.0 beta 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-UserInterfaceState.xcuserstate
-Toucan.xccheckout
-Toucan.xcworkspace/xcuserdata/*.xcuserdatad
+*.xcuserstate
+xcuserdata
+*.xccheckout
 build
 .idea
 docs

--- a/Source/Toucan.swift
+++ b/Source/Toucan.swift
@@ -447,7 +447,7 @@ public class Toucan : NSObject {
     }
     
     /**
-    Container struct for all things Layer related
+    Container struct for all things Layer related.
     */
     public struct Layer {
         
@@ -564,7 +564,7 @@ public class Toucan : NSObject {
         }
         
         /**
-        Crap the image within the given rect (i.e. resizes and crops)
+        Crop the image within the given rect (i.e. resizes and crops)
         
         - parameter image: Image to clip within the given rect bounds
         - parameter rect:  Bounds to draw the image within
@@ -589,7 +589,7 @@ public class Toucan : NSObject {
         */
         static func drawImageWithClosure(size size: CGSize!, closure: (size: CGSize, context: CGContext) -> ()) -> UIImage {
             UIGraphicsBeginImageContextWithOptions(size, false, 0)
-            closure(size: size, context: UIGraphicsGetCurrentContext())
+            closure(size: size, context: UIGraphicsGetCurrentContext()!)
             let image : UIImage = UIGraphicsGetImageFromCurrentImageContext()
             UIGraphicsEndImageContext()
             return image


### PR DESCRIPTION
Toucan is failing to build with Xcode 7.0 beta 5 because of an optional mismatch with respect to `UIGraphicsGetCurrentContext()` in `Util.drawImageWithClosure()`. This fixes it.

(While not the most 100% right fix [because apparently `UIGraphicsGetCurrentContext()` can fail and return `nil`?] this seems to be a more ideal fix. Otherwise you'd have to change all the `UIImage` return parameters to be optional, which would be a usability regression for the Toucan API. I've never seen `UIGraphicsGetCurrentContext()` fail in practice, so it's probably okay. What do you think @gavinbunney?)