### PR TITLE
Fix image height

### DIFF
--- a/Source/Toucan.swift
+++ b/Source/Toucan.swift
@@ -527,7 +527,7 @@ public class Toucan : NSObject {
                     break
             }
             
-            let context : CGContextRef = CGBitmapContextCreate(nil, CGImageGetWidth(image.CGImage), CGImageGetWidth(image.CGImage),
+            let context : CGContextRef = CGBitmapContextCreate(nil, CGImageGetWidth(image.CGImage), CGImageGetHeight(image.CGImage),
                 CGImageGetBitsPerComponent(image.CGImage),
                 CGImageGetBytesPerRow(image.CGImage),
                 CGImageGetColorSpace(image.CGImage),


### PR DESCRIPTION
After updating to >= 0.3.1, all my images became stretched/scaled after calling `resizeImage`. It looks like this was just a typo.