### PR TITLE
Fix image dimensions for rotated images (left or right)

### DIFF
--- a/Source/Toucan.swift
+++ b/Source/Toucan.swift
@@ -526,24 +526,30 @@ public class Toucan : NSObject {
                 default:
                     break
             }
-            
-            let context : CGContextRef = CGBitmapContextCreate(nil, CGImageGetWidth(image.CGImage), CGImageGetHeight(image.CGImage),
+
+            let contextWidth : Int
+            let contextHeight : Int
+
+            switch (image.imageOrientation) {
+                case UIImageOrientation.Left, UIImageOrientation.LeftMirrored,
+                     UIImageOrientation.Right, UIImageOrientation.RightMirrored:
+                    contextWidth = CGImageGetHeight(image.CGImage)
+                    contextHeight = CGImageGetWidth(image.CGImage)
+                    break
+                default:
+                    contextWidth = CGImageGetWidth(image.CGImage)
+                    contextHeight = CGImageGetHeight(image.CGImage)
+                    break
+            }
+
+            let context : CGContextRef = CGBitmapContextCreate(nil, contextWidth, contextHeight,
                 CGImageGetBitsPerComponent(image.CGImage),
                 CGImageGetBytesPerRow(image.CGImage),
                 CGImageGetColorSpace(image.CGImage),
                 CGImageGetBitmapInfo(image.CGImage).rawValue)!;
             
             CGContextConcatCTM(context, transform);
-            
-            switch (image.imageOrientation) {
-                case UIImageOrientation.Left, UIImageOrientation.LeftMirrored,
-                     UIImageOrientation.Right, UIImageOrientation.RightMirrored:
-                    CGContextDrawImage(context, CGRectMake(0, 0, image.size.height, image.size.width), image.CGImage);
-                    break;
-                default:
-                    CGContextDrawImage(context, CGRectMake(0, 0, image.size.width, image.size.height), image.CGImage);
-                    break;
-            }
+            CGContextDrawImage(context, CGRectMake(0, 0, CGFloat(contextWidth), CGFloat(contextHeight)), image.CGImage);
             
             let cgImage = CGBitmapContextCreateImage(context);
             return cgImage!;


### PR DESCRIPTION
It looks like the image dimensions are swapped for left or right orientated images.  I get stretched/scaled images after calling `resizeImage` when the image orientation is left, left mirrored, right, or right mirrored (for example, images from the device camera in portrait orientation).  This seemed to fix the issue.

If we could get another v3 release as well, that would be great.  [Here are my changes for v3.](https://github.com/djtarazona/Toucan/commit/2c0415ddd2f2e1bf9ebed4f8cc6b28bf5692fd85)