### PR TITLE
Migrate to Swift 3 (most of the public APIs intact)

### DIFF
--- a/Source/Toucan-Info.plist
+++ b/Source/Toucan-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1</string>
+	<string>0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Toucan.swift
+++ b/Source/Toucan.swift
@@ -24,17 +24,17 @@ import UIKit
 import CoreGraphics
 
 /**
-Toucan - Fabulous Image Processing in Swift.
-
-The Toucan class provides two methods of interaction - either through an instance, wrapping an single image,
-or through the static functions, providing an image for each invocation.
-
-This allows for some flexible usage. Using static methods when you need a single operation:
-let resizedImage = Toucan.resize(myImage, size: CGSize(width: 100, height: 150))
-
-Or create an instance for easy method chaining:
-let resizedAndMaskedImage = Toucan(withImage: myImage).resize(CGSize(width: 100, height: 150)).maskWithEllipse().image
-*/
+ Toucan - Fabulous Image Processing in Swift.
+ 
+ The Toucan class provides two methods of interaction - either through an instance, wrapping an single image,
+ or through the static functions, providing an image for each invocation.
+ 
+ This allows for some flexible usage. Using static methods when you need a single operation:
+ let resizedImage = Toucan.resize(myImage, size: CGSize(width: 100, height: 150))
+ 
+ Or create an instance for easy method chaining:
+ let resizedAndMaskedImage = Toucan(withImage: myImage).resize(CGSize(width: 100, height: 150)).maskWithEllipse().image
+ */
 public class Toucan : NSObject {
     
     public var image : UIImage
@@ -46,120 +46,120 @@ public class Toucan : NSObject {
     // MARK: - Resize
     
     /**
-    Resize the contained image to the specified size. Depending on what fitMode is supplied, the image
-    may be clipped, cropped or scaled. @see documentation on FitMode.
-    
-    The current image on this toucan instance is replaced with the resized image.
-    
-    - parameter size:    Size to resize the image to
-    - parameter fitMode: How to handle the image resizing process
-    
-    - returns: Self, allowing method chaining
-    */
-    public func resize(size: CGSize, fitMode: Toucan.Resize.FitMode = .Clip) -> Toucan {
+     Resize the contained image to the specified size. Depending on what fitMode is supplied, the image
+     may be clipped, cropped or scaled. @see documentation on FitMode.
+     
+     The current image on this toucan instance is replaced with the resized image.
+     
+     - parameter size:    Size to resize the image to
+     - parameter fitMode: How to handle the image resizing process
+     
+     - returns: Self, allowing method chaining
+     */
+    public func resize(_ size: CGSize, fitMode: Toucan.Resize.FitMode = .clip) -> Toucan {
         self.image = Toucan.Resize.resizeImage(self.image, size: size, fitMode: fitMode)
         return self
     }
     
     /**
-    Resize the contained image to the specified size by resizing the image to fit
-    within the width and height boundaries without cropping or scaling the image.
-    
-    The current image on this toucan instance is replaced with the resized image.
-    
-    - parameter size:    Size to resize the image to
-    
-    - returns: Self, allowing method chaining
-    */
+     Resize the contained image to the specified size by resizing the image to fit
+     within the width and height boundaries without cropping or scaling the image.
+     
+     The current image on this toucan instance is replaced with the resized image.
+     
+     - parameter size:    Size to resize the image to
+     
+     - returns: Self, allowing method chaining
+     */
     @objc
-    public func resizeByClipping(size: CGSize) -> Toucan {
-        self.image = Toucan.Resize.resizeImage(self.image, size: size, fitMode: .Clip)
+    public func resizeByClipping(_ size: CGSize) -> Toucan {
+        self.image = Toucan.Resize.resizeImage(self.image, size: size, fitMode: .clip)
         return self
     }
     
     /**
-    Resize the contained image to the specified size by resizing the image to fill the
-    width and height boundaries and crops any excess image data.
-    The resulting image will match the width and height constraints without scaling the image.
-    
-    The current image on this toucan instance is replaced with the resized image.
-    
-    - parameter size:    Size to resize the image to
-    
-    - returns: Self, allowing method chaining
-    */
+     Resize the contained image to the specified size by resizing the image to fill the
+     width and height boundaries and crops any excess image data.
+     The resulting image will match the width and height constraints without scaling the image.
+     
+     The current image on this toucan instance is replaced with the resized image.
+     
+     - parameter size:    Size to resize the image to
+     
+     - returns: Self, allowing method chaining
+     */
     @objc
-    public func resizeByCropping(size: CGSize) -> Toucan {
-        self.image = Toucan.Resize.resizeImage(self.image, size: size, fitMode: .Crop)
+    public func resizeByCropping(_ size: CGSize) -> Toucan {
+        self.image = Toucan.Resize.resizeImage(self.image, size: size, fitMode: .crop)
         return self
     }
     
     /**
-    Resize the contained image to the specified size by scaling the image to fit the
-    constraining dimensions exactly.
-    
-    The current image on this toucan instance is replaced with the resized image.
-    
-    - parameter size:    Size to resize the image to
-    
-    - returns: Self, allowing method chaining
-    */
+     Resize the contained image to the specified size by scaling the image to fit the
+     constraining dimensions exactly.
+     
+     The current image on this toucan instance is replaced with the resized image.
+     
+     - parameter size:    Size to resize the image to
+     
+     - returns: Self, allowing method chaining
+     */
     @objc
-    public func resizeByScaling(size: CGSize) -> Toucan {
-        self.image = Toucan.Resize.resizeImage(self.image, size: size, fitMode: .Scale)
+    public func resizeByScaling(_ size: CGSize) -> Toucan {
+        self.image = Toucan.Resize.resizeImage(self.image, size: size, fitMode: .scale)
         return self
     }
     
     /**
-    Container struct for all things Resize related
-    */
+     Container struct for all things Resize related
+     */
     public struct Resize {
         
         /**
-        FitMode drives the resizing process to determine what to do with an image to
-        make it fit the given size bounds.
-        
-        - Clip:  Resizes the image to fit within the width and height boundaries without cropping or scaling the image.
-        
-        - Crop:  Resizes the image to fill the width and height boundaries and crops any excess image data.
-        
-        - Scale: Scales the image to fit the constraining dimensions exactly.
-        */
+         FitMode drives the resizing process to determine what to do with an image to
+         make it fit the given size bounds.
+         
+         - Clip:  Resizes the image to fit within the width and height boundaries without cropping or scaling the image.
+         
+         - Crop:  Resizes the image to fill the width and height boundaries and crops any excess image data.
+         
+         - Scale: Scales the image to fit the constraining dimensions exactly.
+         */
         public enum FitMode {
             /**
-            Resizes the image to fit within the width and height boundaries without cropping or scaling the image.
-            The resulting image is assured to match one of the constraining dimensions, while
-            the other dimension is altered to maintain the same aspect ratio of the input image.
-            */
-            case Clip
+             Resizes the image to fit within the width and height boundaries without cropping or scaling the image.
+             The resulting image is assured to match one of the constraining dimensions, while
+             the other dimension is altered to maintain the same aspect ratio of the input image.
+             */
+            case clip
             
             /**
-            Resizes the image to fill the width and height boundaries and crops any excess image data.
-            The resulting image will match the width and height constraints without scaling the image.
-            */
-            case Crop
+             Resizes the image to fill the width and height boundaries and crops any excess image data.
+             The resulting image will match the width and height constraints without scaling the image.
+             */
+            case crop
             
             /**
-            Scales the image to fit the constraining dimensions exactly.
-            */
-            case Scale
+             Scales the image to fit the constraining dimensions exactly.
+             */
+            case scale
         }
         
         /**
-        Resize an image to the specified size. Depending on what fitMode is supplied, the image
-        may be clipped, cropped or scaled. @see documentation on FitMode.
-        
-        - parameter image:   Image to Resize
-        - parameter size:    Size to resize the image to
-        - parameter fitMode: How to handle the image resizing process
-        
-        - returns: Resized image
-        */
-        public static func resizeImage(image: UIImage, size: CGSize, fitMode: FitMode = .Clip) -> UIImage {
+         Resize an image to the specified size. Depending on what fitMode is supplied, the image
+         may be clipped, cropped or scaled. @see documentation on FitMode.
+         
+         - parameter image:   Image to Resize
+         - parameter size:    Size to resize the image to
+         - parameter fitMode: How to handle the image resizing process
+         
+         - returns: Resized image
+         */
+        public static func resizeImage(_ image: UIImage, size: CGSize, fitMode: FitMode = .clip) -> UIImage {
             
             let imgRef = Util.CGImageWithCorrectOrientation(image)
-            let originalWidth  = CGFloat(CGImageGetWidth(imgRef))
-            let originalHeight = CGFloat(CGImageGetHeight(imgRef))
+            let originalWidth  = CGFloat(imgRef.width)
+            let originalHeight = CGFloat(imgRef.height)
             let widthRatio = size.width / originalWidth
             let heightRatio = size.height / originalHeight
             
@@ -169,14 +169,14 @@ public class Toucan : NSObject {
             let resizedImage = Util.drawImageInBounds(image, bounds: resizedImageBounds)
             
             switch (fitMode) {
-            case .Clip:
+            case .clip:
                 return resizedImage
-            case .Crop:
+            case .crop:
                 let croppedRect = CGRect(x: (resizedImage.size.width - size.width) / 2,
-                    y: (resizedImage.size.height - size.height) / 2,
-                    width: size.width, height: size.height)
+                                         y: (resizedImage.size.height - size.height) / 2,
+                                         width: size.width, height: size.height)
                 return Util.croppedImageWithRect(resizedImage, rect: croppedRect)
-            case .Scale:
+            case .scale:
                 return Util.drawImageInBounds(resizedImage, bounds: CGRect(x: 0, y: 0, width: size.width, height: size.height))
             }
         }
@@ -185,418 +185,418 @@ public class Toucan : NSObject {
     // MARK: - Mask
     
     /**
-    Mask the contained image with another image mask.
-    Note that the areas in the original image that correspond to the black areas of the mask
-    show through in the resulting image. The areas that correspond to the white areas of
-    the mask aren’t painted. The areas that correspond to the gray areas in the mask are painted
-    using an intermediate alpha value that’s equal to 1 minus the image mask sample value.
-    
-    - parameter maskImage: Image Mask to apply to the Image
-    
-    - returns: Self, allowing method chaining
-    */
-    public func maskWithImage(maskImage maskImage : UIImage)  -> Toucan {
+     Mask the contained image with another image mask.
+     Note that the areas in the original image that correspond to the black areas of the mask
+     show through in the resulting image. The areas that correspond to the white areas of
+     the mask aren’t painted. The areas that correspond to the gray areas in the mask are painted
+     using an intermediate alpha value that’s equal to 1 minus the image mask sample value.
+     
+     - parameter maskImage: Image Mask to apply to the Image
+     
+     - returns: Self, allowing method chaining
+     */
+    public func maskWithImage(maskImage : UIImage)  -> Toucan {
         self.image = Toucan.Mask.maskImageWithImage(self.image, maskImage: maskImage)
         return self
     }
     
     /**
-    Mask the contained image with an ellipse.
-    Allows specifying an additional border to draw on the clipped image.
-    For a circle, ensure the image width and height are equal!
-    
-    - parameter borderWidth: Optional width of the border to apply - default 0
-    - parameter borderColor: Optional color of the border - default White
-    
-    - returns: Self, allowing method chaining
-    */
-    public func maskWithEllipse(borderWidth borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.whiteColor()) -> Toucan {
+     Mask the contained image with an ellipse.
+     Allows specifying an additional border to draw on the clipped image.
+     For a circle, ensure the image width and height are equal!
+     
+     - parameter borderWidth: Optional width of the border to apply - default 0
+     - parameter borderColor: Optional color of the border - default White
+     
+     - returns: Self, allowing method chaining
+     */
+    public func maskWithEllipse(borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.white) -> Toucan {
         self.image = Toucan.Mask.maskImageWithEllipse(self.image, borderWidth: borderWidth, borderColor: borderColor)
         return self
     }
     
     /**
-    Mask the contained image with a path (UIBezierPath) that will be scaled to fit the image.
-    
-    - parameter path: UIBezierPath to mask the image
-    
-    - returns: Self, allowing method chaining
-    */
-    public func maskWithPath(path path: UIBezierPath) -> Toucan {
+     Mask the contained image with a path (UIBezierPath) that will be scaled to fit the image.
+     
+     - parameter path: UIBezierPath to mask the image
+     
+     - returns: Self, allowing method chaining
+     */
+    public func maskWithPath(path: UIBezierPath) -> Toucan {
         self.image = Toucan.Mask.maskImageWithPath(self.image, path: path)
         return self
     }
     
     /**
-    Mask the contained image with a path (UIBezierPath) which is provided via a closure.
-    
-    - parameter path: closure that returns a UIBezierPath. Using a closure allows the user to provide the path after knowing the size of the image
-    
-    - returns: Self, allowing method chaining
-    */
-    public func maskWithPathClosure(path path: (rect: CGRect) -> (UIBezierPath)) -> Toucan {
+     Mask the contained image with a path (UIBezierPath) which is provided via a closure.
+     
+     - parameter path: closure that returns a UIBezierPath. Using a closure allows the user to provide the path after knowing the size of the image
+     
+     - returns: Self, allowing method chaining
+     */
+    public func maskWithPathClosure(path: (_ rect: CGRect) -> (UIBezierPath)) -> Toucan {
         self.image = Toucan.Mask.maskImageWithPathClosure(self.image, pathInRect: path)
         return self
     }
     
     /**
-    Mask the contained image with a rounded rectangle border.
-    Allows specifying an additional border to draw on the clipped image.
-    
-    - parameter cornerRadius: Radius of the rounded rect corners
-    - parameter borderWidth:  Optional width of border to apply - default 0
-    - parameter borderColor:  Optional color of the border - default White
-    
-    - returns: Self, allowing method chaining
-    */
-    public func maskWithRoundedRect(cornerRadius cornerRadius: CGFloat, borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.whiteColor()) -> Toucan {
+     Mask the contained image with a rounded rectangle border.
+     Allows specifying an additional border to draw on the clipped image.
+     
+     - parameter cornerRadius: Radius of the rounded rect corners
+     - parameter borderWidth:  Optional width of border to apply - default 0
+     - parameter borderColor:  Optional color of the border - default White
+     
+     - returns: Self, allowing method chaining
+     */
+    public func maskWithRoundedRect(cornerRadius: CGFloat, borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.white) -> Toucan {
         self.image = Toucan.Mask.maskImageWithRoundedRect(self.image, cornerRadius: cornerRadius, borderWidth: borderWidth, borderColor: borderColor)
         return self
     }
     
     /**
-    Container struct for all things Mask related
-    */
+     Container struct for all things Mask related
+     */
     public struct Mask {
         
         /**
-        Mask the given image with another image mask.
-        Note that the areas in the original image that correspond to the black areas of the mask
-        show through in the resulting image. The areas that correspond to the white areas of
-        the mask aren’t painted. The areas that correspond to the gray areas in the mask are painted
-        using an intermediate alpha value that’s equal to 1 minus the image mask sample value.
-        
-        - parameter image:     Image to apply the mask to
-        - parameter maskImage: Image Mask to apply to the Image
-        
-        - returns: Masked image
-        */
-        public static func maskImageWithImage(image: UIImage, maskImage: UIImage) -> UIImage {
+         Mask the given image with another image mask.
+         Note that the areas in the original image that correspond to the black areas of the mask
+         show through in the resulting image. The areas that correspond to the white areas of
+         the mask aren’t painted. The areas that correspond to the gray areas in the mask are painted
+         using an intermediate alpha value that’s equal to 1 minus the image mask sample value.
+         
+         - parameter image:     Image to apply the mask to
+         - parameter maskImage: Image Mask to apply to the Image
+         
+         - returns: Masked image
+         */
+        public static func maskImageWithImage(_ image: UIImage, maskImage: UIImage) -> UIImage {
             
             let imgRef = Util.CGImageWithCorrectOrientation(image)
-            let maskRef = maskImage.CGImage
+            let maskRef = maskImage.cgImage
             
-            let mask = CGImageMaskCreate(CGImageGetWidth(maskRef),
-                CGImageGetHeight(maskRef),
-                CGImageGetBitsPerComponent(maskRef),
-                CGImageGetBitsPerPixel(maskRef),
-                CGImageGetBytesPerRow(maskRef),
-                CGImageGetDataProvider(maskRef), nil, false);
+            let mask = CGImage(maskWidth: (maskRef?.width)!,
+                               height: (maskRef?.height)!,
+                               bitsPerComponent: (maskRef?.bitsPerComponent)!,
+                               bitsPerPixel: (maskRef?.bitsPerPixel)!,
+                               bytesPerRow: (maskRef?.bytesPerRow)!,
+                               provider: (maskRef?.dataProvider!)!, decode: nil, shouldInterpolate: false);
             
-            let masked = CGImageCreateWithMask(imgRef, mask);
+            let masked = imgRef.masking(mask!);
             
             return Util.drawImageWithClosure(size: image.size) { (size: CGSize, context: CGContext) -> () in
                 
                 // need to flip the transform matrix, CoreGraphics has (0,0) in lower left when drawing image
-                CGContextScaleCTM(context, 1, -1)
-                CGContextTranslateCTM(context, 0, -size.height)
+                context.scaleBy(x: 1, y: -1)
+                context.translateBy(x: 0, y: -size.height)
                 
-                CGContextDrawImage(context, CGRect(x: 0, y: 0, width: size.width, height: size.height), masked);
+                context.draw(masked!, in: CGRect(x: 0, y: 0, width: size.width, height: size.height));
             }
         }
         
         /**
-        Mask the given image with an ellipse.
-        Allows specifying an additional border to draw on the clipped image.
-        For a circle, ensure the image width and height are equal!
-        
-        - parameter image:       Image to apply the mask to
-        - parameter borderWidth: Optional width of the border to apply - default 0
-        - parameter borderColor: Optional color of the border - default White
-        
-        - returns: Masked image
-        */
-        public static func maskImageWithEllipse(image: UIImage,
-            borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.whiteColor()) -> UIImage {
+         Mask the given image with an ellipse.
+         Allows specifying an additional border to draw on the clipped image.
+         For a circle, ensure the image width and height are equal!
+         
+         - parameter image:       Image to apply the mask to
+         - parameter borderWidth: Optional width of the border to apply - default 0
+         - parameter borderColor: Optional color of the border - default White
+         
+         - returns: Masked image
+         */
+        public static func maskImageWithEllipse(_ image: UIImage,
+                                                borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.white) -> UIImage {
+            
+            let imgRef = Util.CGImageWithCorrectOrientation(image)
+            let size = CGSize(width: CGFloat(imgRef.width) / image.scale, height: CGFloat(imgRef.height) / image.scale)
+            
+            return Util.drawImageWithClosure(size: size) { (size: CGSize, context: CGContext) -> () in
                 
-                let imgRef = Util.CGImageWithCorrectOrientation(image)
-                let size = CGSize(width: CGFloat(CGImageGetWidth(imgRef)) / image.scale, height: CGFloat(CGImageGetHeight(imgRef)) / image.scale)
+                let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
                 
-                return Util.drawImageWithClosure(size: size) { (size: CGSize, context: CGContext) -> () in
-                    
-                    let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-                    
-                    CGContextAddEllipseInRect(context, rect)
-                    CGContextClip(context)
-                    image.drawInRect(rect)
-                    
-                    if (borderWidth > 0) {
-                        CGContextSetStrokeColorWithColor(context, borderColor.CGColor);
-                        CGContextSetLineWidth(context, borderWidth);
-                        CGContextAddEllipseInRect(context, CGRect(x: borderWidth / 2,
-                            y: borderWidth / 2,
-                            width: size.width - borderWidth,
-                            height: size.height - borderWidth));
-                        CGContextStrokePath(context);
-                    }
+                context.addEllipse(in: rect)
+                context.clip()
+                image.draw(in: rect)
+                
+                if (borderWidth > 0) {
+                    context.setStrokeColor(borderColor.cgColor);
+                    context.setLineWidth(borderWidth);
+                    context.addEllipse(in: CGRect(x: borderWidth / 2,
+                                                  y: borderWidth / 2,
+                                                  width: size.width - borderWidth,
+                                                  height: size.height - borderWidth));
+                    context.strokePath();
                 }
+            }
         }
         
         /**
-        Mask the given image with a path(UIBezierPath) that will be scaled to fit the image.
-        
-        - parameter image:       Image to apply the mask to
-        - parameter path: UIBezierPath to make as the mask
-        
-        - returns: Masked image
-        */
-        public static func maskImageWithPath(image: UIImage,
-            path: UIBezierPath) -> UIImage {
+         Mask the given image with a path(UIBezierPath) that will be scaled to fit the image.
+         
+         - parameter image:       Image to apply the mask to
+         - parameter path: UIBezierPath to make as the mask
+         
+         - returns: Masked image
+         */
+        public static func maskImageWithPath(_ image: UIImage,
+                                             path: UIBezierPath) -> UIImage {
+            
+            let imgRef = Util.CGImageWithCorrectOrientation(image)
+            let size = CGSize(width: CGFloat(imgRef.width) / image.scale, height: CGFloat(imgRef.height) / image.scale)
+            
+            return Util.drawImageWithClosure(size: size) { (size: CGSize, context: CGContext) -> () in
                 
-                let imgRef = Util.CGImageWithCorrectOrientation(image)
-                let size = CGSize(width: CGFloat(CGImageGetWidth(imgRef)) / image.scale, height: CGFloat(CGImageGetHeight(imgRef)) / image.scale)
+                let boundSize = path.bounds.size
                 
-                return Util.drawImageWithClosure(size: size) { (size: CGSize, context: CGContext) -> () in
-                    
-                    let boundSize = path.bounds.size
-                    
-                    let pathRatio = boundSize.width / boundSize.height
-                    let imageRatio = size.width / size.height
-                    
-                    
-                    if pathRatio > imageRatio {
-                        //scale based on width
-                        let scale = size.width / boundSize.width
-                        path.applyTransform(CGAffineTransformMakeScale(scale, scale))
-                        path.applyTransform(CGAffineTransformMakeTranslation(0, (size.height - path.bounds.height) / 2.0))
-                    } else {
-                        //scale based on height
-                        let scale = size.height / boundSize.height
-                        path.applyTransform(CGAffineTransformMakeScale(scale, scale))
-                        path.applyTransform(CGAffineTransformMakeTranslation((size.width - path.bounds.width) / 2.0, 0))
-                    }
-                    
-                    let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-                    
-                    CGContextAddPath(context, path.CGPath)
-                    CGContextClip(context)
-                    image.drawInRect(rect)
+                let pathRatio = boundSize.width / boundSize.height
+                let imageRatio = size.width / size.height
+                
+                
+                if pathRatio > imageRatio {
+                    //scale based on width
+                    let scale = size.width / boundSize.width
+                    path.apply(CGAffineTransform(scaleX: scale, y: scale))
+                    path.apply(CGAffineTransform(translationX: 0, y: (size.height - path.bounds.height) / 2.0))
+                } else {
+                    //scale based on height
+                    let scale = size.height / boundSize.height
+                    path.apply(CGAffineTransform(scaleX: scale, y: scale))
+                    path.apply(CGAffineTransform(translationX: (size.width - path.bounds.width) / 2.0, y: 0))
                 }
+                
+                let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+                
+                context.addPath(path.cgPath)
+                context.clip()
+                image.draw(in: rect)
+            }
         }
         
         /**
-        Mask the given image with a path(UIBezierPath) provided via a closure. This allows the user to get the size of the image before computing their path variable.
-        
-        - parameter image:       Image to apply the mask to
-        - parameter path: UIBezierPath to make as the mask
-        
-        - returns: Masked image
-        */
-        public static func maskImageWithPathClosure(image: UIImage,
-            pathInRect:(rect: CGRect) -> (UIBezierPath)) -> UIImage {
-                
-                let imgRef = Util.CGImageWithCorrectOrientation(image)
-                let size = CGSize(width: CGFloat(CGImageGetWidth(imgRef)) / image.scale, height: CGFloat(CGImageGetHeight(imgRef)) / image.scale)
-                
-                return maskImageWithPath(image, path: pathInRect(rect: CGRectMake(0, 0, size.width, size.height)))
+         Mask the given image with a path(UIBezierPath) provided via a closure. This allows the user to get the size of the image before computing their path variable.
+         
+         - parameter image:       Image to apply the mask to
+         - parameter path: UIBezierPath to make as the mask
+         
+         - returns: Masked image
+         */
+        public static func maskImageWithPathClosure(_ image: UIImage,
+                                                    pathInRect:(_ rect: CGRect) -> (UIBezierPath)) -> UIImage {
+            
+            let imgRef = Util.CGImageWithCorrectOrientation(image)
+            let size = CGSize(width: CGFloat(imgRef.width) / image.scale, height: CGFloat(imgRef.height) / image.scale)
+            
+            return maskImageWithPath(image, path: pathInRect(CGRect(x: 0, y: 0, width: size.width, height: size.height)))
         }
         
         /**
-        Mask the given image with a rounded rectangle border.
-        Allows specifying an additional border to draw on the clipped image.
-        
-        - parameter image:        Image to apply the mask to
-        - parameter cornerRadius: Radius of the rounded rect corners
-        - parameter borderWidth:  Optional width of border to apply - default 0
-        - parameter borderColor:  Optional color of the border - default White
-        
-        - returns: Masked image
-        */
-        public static func maskImageWithRoundedRect(image: UIImage, cornerRadius: CGFloat,
-            borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.whiteColor()) -> UIImage {
+         Mask the given image with a rounded rectangle border.
+         Allows specifying an additional border to draw on the clipped image.
+         
+         - parameter image:        Image to apply the mask to
+         - parameter cornerRadius: Radius of the rounded rect corners
+         - parameter borderWidth:  Optional width of border to apply - default 0
+         - parameter borderColor:  Optional color of the border - default White
+         
+         - returns: Masked image
+         */
+        public static func maskImageWithRoundedRect(_ image: UIImage, cornerRadius: CGFloat,
+                                                    borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.white) -> UIImage {
+            
+            let imgRef = Util.CGImageWithCorrectOrientation(image)
+            let size = CGSize(width: CGFloat(imgRef.width) / image.scale, height: CGFloat(imgRef.height) / image.scale)
+            
+            return Util.drawImageWithClosure(size: size) { (size: CGSize, context: CGContext) -> () in
                 
-                let imgRef = Util.CGImageWithCorrectOrientation(image)
-                let size = CGSize(width: CGFloat(CGImageGetWidth(imgRef)) / image.scale, height: CGFloat(CGImageGetHeight(imgRef)) / image.scale)
+                let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
                 
-                return Util.drawImageWithClosure(size: size) { (size: CGSize, context: CGContext) -> () in
+                UIBezierPath(roundedRect:rect, cornerRadius: cornerRadius).addClip()
+                image.draw(in: rect)
+                
+                if (borderWidth > 0) {
+                    context.setStrokeColor(borderColor.cgColor);
+                    context.setLineWidth(borderWidth);
                     
-                    let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+                    let borderRect = CGRect(x: 0, y: 0,
+                                            width: size.width, height: size.height)
                     
-                    UIBezierPath(roundedRect:rect, cornerRadius: cornerRadius).addClip()
-                    image.drawInRect(rect)
-                    
-                    if (borderWidth > 0) {
-                        CGContextSetStrokeColorWithColor(context, borderColor.CGColor);
-                        CGContextSetLineWidth(context, borderWidth);
-                        
-                        let borderRect = CGRect(x: 0, y: 0,
-                            width: size.width, height: size.height)
-                        
-                        let borderPath = UIBezierPath(roundedRect: borderRect, cornerRadius: cornerRadius)
-                        borderPath.lineWidth = borderWidth * 2
-                        borderPath.stroke()
-                    }
+                    let borderPath = UIBezierPath(roundedRect: borderRect, cornerRadius: cornerRadius)
+                    borderPath.lineWidth = borderWidth * 2
+                    borderPath.stroke()
                 }
+            }
         }
     }
     
     // MARK: - Layer
     
     /**
-    Overlay an image ontop of the current image.
-    
-    - parameter image:        Image to be on the bottom layer
-    - parameter overlayImage: Image to be on the top layer, i.e. drawn on top of image
-    - parameter overlayFrame: Frame of the overlay image
-    
-    - returns: Self, allowing method chaining
-    */
-    public func layerWithOverlayImage(overlayImage: UIImage, overlayFrame: CGRect) -> Toucan {
+     Overlay an image ontop of the current image.
+     
+     - parameter image:        Image to be on the bottom layer
+     - parameter overlayImage: Image to be on the top layer, i.e. drawn on top of image
+     - parameter overlayFrame: Frame of the overlay image
+     
+     - returns: Self, allowing method chaining
+     */
+    public func layerWithOverlayImage(_ overlayImage: UIImage, overlayFrame: CGRect) -> Toucan {
         self.image = Toucan.Layer.overlayImage(self.image, overlayImage:overlayImage, overlayFrame:overlayFrame)
         return self
     }
     
     /**
-    Container struct for all things Layer related.
-    */
+     Container struct for all things Layer related.
+     */
     public struct Layer {
         
         /**
-        Overlay the given image into a new layout ontop of the image.
-        
-        - parameter image:        Image to be on the bottom layer
-        - parameter overlayImage: Image to be on the top layer, i.e. drawn on top of image
-        - parameter overlayFrame: Frame of the overlay image
-        
-        - returns: Masked image
-        */
-        public static func overlayImage(image: UIImage, overlayImage: UIImage, overlayFrame: CGRect) -> UIImage {
+         Overlay the given image into a new layout ontop of the image.
+         
+         - parameter image:        Image to be on the bottom layer
+         - parameter overlayImage: Image to be on the top layer, i.e. drawn on top of image
+         - parameter overlayFrame: Frame of the overlay image
+         
+         - returns: Masked image
+         */
+        public static func overlayImage(_ image: UIImage, overlayImage: UIImage, overlayFrame: CGRect) -> UIImage {
             
             let imgRef = Util.CGImageWithCorrectOrientation(image)
-            let size = CGSize(width: CGFloat(CGImageGetWidth(imgRef)) / image.scale, height: CGFloat(CGImageGetHeight(imgRef)) / image.scale)
+            let size = CGSize(width: CGFloat(imgRef.width) / image.scale, height: CGFloat(imgRef.height) / image.scale)
             
             return Util.drawImageWithClosure(size: size) { (size: CGSize, context: CGContext) -> () in
                 
                 let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
                 
-                image.drawInRect(rect)
-                overlayImage.drawInRect(overlayFrame);
+                image.draw(in: rect)
+                overlayImage.draw(in: overlayFrame);
             }
         }
     }
     
     /**
-    Container struct for internally used utility functions.
-    */
+     Container struct for internally used utility functions.
+     */
     internal struct Util {
         
         /**
-        Get the CGImage of the image with the orientation fixed up based on EXF data.
-        This helps to normalise input images to always be the correct orientation when performing
-        other core graphics tasks on the image.
-        
-        - parameter image: Image to create CGImageRef for
-        
-        - returns: CGImageRef with rotated/transformed image context
-        */
-        static func CGImageWithCorrectOrientation(image : UIImage) -> CGImageRef {
+         Get the CGImage of the image with the orientation fixed up based on EXF data.
+         This helps to normalise input images to always be the correct orientation when performing
+         other core graphics tasks on the image.
+         
+         - parameter image: Image to create CGImageRef for
+         
+         - returns: CGImageRef with rotated/transformed image context
+         */
+        static func CGImageWithCorrectOrientation(_ image : UIImage) -> CGImage {
             
-            if (image.imageOrientation == UIImageOrientation.Up) {
-                return image.CGImage!
+            if (image.imageOrientation == UIImageOrientation.up) {
+                return image.cgImage!
             }
             
-            var transform : CGAffineTransform = CGAffineTransformIdentity;
+            var transform : CGAffineTransform = CGAffineTransform.identity;
             
             switch (image.imageOrientation) {
-                case UIImageOrientation.Right, UIImageOrientation.RightMirrored:
-                    transform = CGAffineTransformTranslate(transform, 0, image.size.height)
-                    transform = CGAffineTransformRotate(transform, CGFloat(-1.0 * M_PI_2))
-                    break
-                case UIImageOrientation.Left, UIImageOrientation.LeftMirrored:
-                    transform = CGAffineTransformTranslate(transform, image.size.width, 0)
-                    transform = CGAffineTransformRotate(transform, CGFloat(M_PI_2))
-                    break
-                case UIImageOrientation.Down, UIImageOrientation.DownMirrored:
-                    transform = CGAffineTransformTranslate(transform, image.size.width, image.size.height)
-                    transform = CGAffineTransformRotate(transform, CGFloat(M_PI))
-                    break
-                default:
-                    break
+            case UIImageOrientation.right, UIImageOrientation.rightMirrored:
+                transform = transform.translatedBy(x: 0, y: image.size.height)
+                transform = transform.rotated(by: CGFloat(-1.0 * M_PI_2))
+                break
+            case UIImageOrientation.left, UIImageOrientation.leftMirrored:
+                transform = transform.translatedBy(x: image.size.width, y: 0)
+                transform = transform.rotated(by: CGFloat(M_PI_2))
+                break
+            case UIImageOrientation.down, UIImageOrientation.downMirrored:
+                transform = transform.translatedBy(x: image.size.width, y: image.size.height)
+                transform = transform.rotated(by: CGFloat(M_PI))
+                break
+            default:
+                break
             }
             
             switch (image.imageOrientation) {
-                case UIImageOrientation.RightMirrored, UIImageOrientation.LeftMirrored:
-                    transform = CGAffineTransformTranslate(transform, image.size.height, 0);
-                    transform = CGAffineTransformScale(transform, -1, 1);
-                    break
-                case UIImageOrientation.DownMirrored, UIImageOrientation.UpMirrored:
-                    transform = CGAffineTransformTranslate(transform, image.size.width, 0);
-                    transform = CGAffineTransformScale(transform, -1, 1);
-                    break
-                default:
-                    break
+            case UIImageOrientation.rightMirrored, UIImageOrientation.leftMirrored:
+                transform = transform.translatedBy(x: image.size.height, y: 0);
+                transform = transform.scaledBy(x: -1, y: 1);
+                break
+            case UIImageOrientation.downMirrored, UIImageOrientation.upMirrored:
+                transform = transform.translatedBy(x: image.size.width, y: 0);
+                transform = transform.scaledBy(x: -1, y: 1);
+                break
+            default:
+                break
             }
-
+            
             let contextWidth : Int
             let contextHeight : Int
-
+            
             switch (image.imageOrientation) {
-                case UIImageOrientation.Left, UIImageOrientation.LeftMirrored,
-                     UIImageOrientation.Right, UIImageOrientation.RightMirrored:
-                    contextWidth = CGImageGetHeight(image.CGImage)
-                    contextHeight = CGImageGetWidth(image.CGImage)
-                    break
-                default:
-                    contextWidth = CGImageGetWidth(image.CGImage)
-                    contextHeight = CGImageGetHeight(image.CGImage)
-                    break
+            case UIImageOrientation.left, UIImageOrientation.leftMirrored,
+                 UIImageOrientation.right, UIImageOrientation.rightMirrored:
+                contextWidth = (image.cgImage?.height)!
+                contextHeight = (image.cgImage?.width)!
+                break
+            default:
+                contextWidth = (image.cgImage?.width)!
+                contextHeight = (image.cgImage?.height)!
+                break
             }
-
-            let context : CGContextRef = CGBitmapContextCreate(nil, contextWidth, contextHeight,
-                CGImageGetBitsPerComponent(image.CGImage),
-                CGImageGetBytesPerRow(image.CGImage),
-                CGImageGetColorSpace(image.CGImage),
-                CGImageGetBitmapInfo(image.CGImage).rawValue)!;
             
-            CGContextConcatCTM(context, transform);
-            CGContextDrawImage(context, CGRectMake(0, 0, CGFloat(contextWidth), CGFloat(contextHeight)), image.CGImage);
+            let context : CGContext = CGContext(data: nil, width: contextWidth, height: contextHeight,
+                                                bitsPerComponent: image.cgImage!.bitsPerComponent,
+                                                bytesPerRow: image.cgImage!.bytesPerRow,
+                                                space: image.cgImage!.colorSpace!,
+                                                bitmapInfo: image.cgImage!.bitmapInfo.rawValue)!;
             
-            let cgImage = CGBitmapContextCreateImage(context);
+            context.concatenate(transform);
+            context.draw(image.cgImage!, in: CGRect(x: 0, y: 0, width: CGFloat(contextWidth), height: CGFloat(contextHeight)));
+            
+            let cgImage = context.makeImage();
             return cgImage!;
         }
         
         /**
-        Draw the image within the given bounds (i.e. resizes)
-        
-        - parameter image:  Image to draw within the given bounds
-        - parameter bounds: Bounds to draw the image within
-        
-        - returns: Resized image within bounds
-        */
-        static func drawImageInBounds(image: UIImage, bounds : CGRect) -> UIImage {
+         Draw the image within the given bounds (i.e. resizes)
+         
+         - parameter image:  Image to draw within the given bounds
+         - parameter bounds: Bounds to draw the image within
+         
+         - returns: Resized image within bounds
+         */
+        static func drawImageInBounds(_ image: UIImage, bounds : CGRect) -> UIImage {
             return drawImageWithClosure(size: bounds.size) { (size: CGSize, context: CGContext) -> () in
-                image.drawInRect(bounds)
+                image.draw(in: bounds)
             };
         }
         
         /**
-        Crop the image within the given rect (i.e. resizes and crops)
-        
-        - parameter image: Image to clip within the given rect bounds
-        - parameter rect:  Bounds to draw the image within
-        
-        - returns: Resized and cropped image
-        */
-        static func croppedImageWithRect(image: UIImage, rect: CGRect) -> UIImage {
+         Crop the image within the given rect (i.e. resizes and crops)
+         
+         - parameter image: Image to clip within the given rect bounds
+         - parameter rect:  Bounds to draw the image within
+         
+         - returns: Resized and cropped image
+         */
+        static func croppedImageWithRect(_ image: UIImage, rect: CGRect) -> UIImage {
             return drawImageWithClosure(size: rect.size) { (size: CGSize, context: CGContext) -> () in
-                let drawRect = CGRectMake(-rect.origin.x, -rect.origin.y, image.size.width, image.size.height)
-                CGContextClipToRect(context, CGRectMake(0, 0, rect.size.width, rect.size.height))
-                image.drawInRect(drawRect)
+                let drawRect = CGRect(x: -rect.origin.x, y: -rect.origin.y, width: image.size.width, height: image.size.height)
+                context.clip(to: CGRect(x: 0, y: 0, width: rect.size.width, height: rect.size.height))
+                image.draw(in: drawRect)
             };
         }
         
         /**
-        Closure wrapper around image context - setting up, ending and grabbing the image from the context.
-        
-        - parameter size:    Size of the graphics context to create
-        - parameter closure: Closure of magic to run in a new context
-        
-        - returns: Image pulled from the end of the closure
-        */
-        static func drawImageWithClosure(size size: CGSize!, closure: (size: CGSize, context: CGContext) -> ()) -> UIImage {
+         Closure wrapper around image context - setting up, ending and grabbing the image from the context.
+         
+         - parameter size:    Size of the graphics context to create
+         - parameter closure: Closure of magic to run in a new context
+         
+         - returns: Image pulled from the end of the closure
+         */
+        static func drawImageWithClosure(size: CGSize!, closure: (_ size: CGSize, _ context: CGContext) -> ()) -> UIImage {
             UIGraphicsBeginImageContextWithOptions(size, false, 0)
-            closure(size: size, context: UIGraphicsGetCurrentContext()!)
-            let image : UIImage = UIGraphicsGetImageFromCurrentImageContext()
+            closure(size, UIGraphicsGetCurrentContext()!)
+            let image : UIImage = UIGraphicsGetImageFromCurrentImageContext()!
             UIGraphicsEndImageContext()
             return image
         }

--- a/Source/tvOS/Toucan.tvOS-Info.plist
+++ b/Source/tvOS/Toucan.tvOS-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/MaskingTests.swift
+++ b/Tests/MaskingTests.swift
@@ -36,12 +36,12 @@ class MaskingTests : ToucanTestCase {
     
     func testMaskWithPath() {
         let path = UIBezierPath()
-        path.moveToPoint(CGPointMake(0, 50))
-        path.addLineToPoint(CGPointMake(50, 0))
-        path.addLineToPoint(CGPointMake(100, 50))
-        path.addLineToPoint(CGPointMake(50, 100))
-        path.closePath()
-        let masked2 = Toucan(image: landscapeImage).resize(CGSizeMake(300, 250), fitMode: Toucan.Resize.FitMode.Scale).maskWithPath(path: path).image
+        path.move(to: CGPoint(x: 0, y: 50))
+        path.addLine(to: CGPoint(x: 50, y: 0))
+        path.addLine(to: CGPoint(x: 100, y: 50))
+        path.addLine(to: CGPoint(x: 50, y: 100))
+        path.close()
+        let masked2 = Toucan(image: landscapeImage).resize(CGSize(width: 300, height: 250), fitMode: Toucan.Resize.FitMode.scale).maskWithPath(path: path).image
         
         let cornerRGBA = getPixelRGBA(masked2, point: CGPoint(x: 0, y: 0))
         XCTAssertEqual(cornerRGBA.alpha, 0.0 as CGFloat, "Check corner is transparent")

--- a/Tests/ResizeTests.swift
+++ b/Tests/ResizeTests.swift
@@ -25,34 +25,34 @@ import Toucan
 class ResizeTests : ToucanTestCase {
     
     func testResizePortraitClipped() {
-        let resized = Toucan(image: portraitImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Clip).image
+        let resized = Toucan(image: portraitImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.clip).image
         XCTAssertEqual(resized.size.width, CGFloat(500), "Verify width equal")
         XCTAssertEqual(resized.size.height, CGFloat(678), "Verify height clipped, so not equal")
     }
     
     func testResizeLandscapeClipped() {
-        let resized = Toucan(image: landscapeImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Clip).image
+        let resized = Toucan(image: landscapeImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.clip).image
         XCTAssertEqual(resized.size.width, CGFloat(747), "Verify width clipped, so not equal")
         XCTAssertEqual(resized.size.height, CGFloat(500), "Verify height equal")
     }
     
     func testResizePortraitCropped() {
-        let resized = Toucan(image: portraitImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Crop).image
+        let resized = Toucan(image: portraitImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.crop).image
         XCTAssertEqual(resized.size, CGSize(width: 500, height: 500), "Verify size equal")
     }
     
     func testResizeLandscapeCropped() {
-        let resized = Toucan(image: landscapeImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Crop).image
+        let resized = Toucan(image: landscapeImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.crop).image
         XCTAssertEqual(resized.size, CGSize(width: 500, height: 500), "Verify size equal")
     }
     
     func testResizePortraitScaled() {
-        let resized = Toucan(image: portraitImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Scale).image
+        let resized = Toucan(image: portraitImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.scale).image
         XCTAssertEqual(resized.size, CGSize(width: 500, height: 500), "Verify size equal")
     }
     
     func testResizeLandscapeScaled() {
-        let resized = Toucan(image: landscapeImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Scale).image
+        let resized = Toucan(image: landscapeImage).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.scale).image
         XCTAssertEqual(resized.size, CGSize(width: 500, height: 500), "Verify size equal")
     }
 }

--- a/Tests/ToucanTestCase.swift
+++ b/Tests/ToucanTestCase.swift
@@ -24,29 +24,29 @@ import XCTest
 class ToucanTestCase : XCTestCase {
 
     internal var portraitImage : UIImage {
-        let imageData = NSData(contentsOfURL: NSBundle(forClass: ToucanTestCase.self).URLForResource("Portrait", withExtension: "jpg")!)
+        let imageData = try? Data(contentsOf: Bundle(for: ToucanTestCase.self).url(forResource: "Portrait", withExtension: "jpg")!)
         let image = UIImage(data: imageData!)
         XCTAssertEqual(image!.size, CGSize(width: 1593, height: 2161), "Verify portrait image size")
         return image!
     }
     
     internal var landscapeImage : UIImage {
-        let imageData = NSData(contentsOfURL: NSBundle(forClass: ToucanTestCase.self).URLForResource("Landscape", withExtension: "jpg")!)
+        let imageData = try? Data(contentsOf: Bundle(for: ToucanTestCase.self).url(forResource: "Landscape", withExtension: "jpg")!)
         let image = UIImage(data: imageData!)
         XCTAssertEqual(image!.size, CGSize(width: 3872, height: 2592), "Verify landscape image size")
         return image!
     }
 
-    internal func getPixelRGBA(image: UIImage, point: CGPoint) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
-        let pixelData : CFDataRef = CGDataProviderCopyData(CGImageGetDataProvider(image.CGImage))!
+    internal func getPixelRGBA(_ image: UIImage, point: CGPoint) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+        let pixelData : CFData = image.cgImage!.dataProvider!.data!
         let data  = CFDataGetBytePtr(pixelData)
         
         let pixelInfo = Int(((image.size.width * point.y) + point.x ) * 4)
         
-        let red = CGFloat(data[pixelInfo])
-        let green = CGFloat(data[pixelInfo + 1])
-        let blue = CGFloat(data[pixelInfo + 2])
-        let alpha = CGFloat(data[pixelInfo + 3])
+        let red = CGFloat((data?[pixelInfo])!)
+        let green = CGFloat((data?[pixelInfo + 1])!)
+        let blue = CGFloat((data?[pixelInfo + 2])!)
+        let alpha = CGFloat((data?[pixelInfo + 3])!)
         
         return (red, green, blue, alpha)
     }

--- a/Toucan.xcodeproj/project.pbxproj
+++ b/Toucan.xcodeproj/project.pbxproj
@@ -235,12 +235,15 @@
 				TargetAttributes = {
 					740AC3E91999799900AB9A86 = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 					};
 					740AC3F41999799900AB9A86 = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 					};
 					C4D770E31C2BF2C800B15C64 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -419,6 +422,7 @@
 		740AC3FE1999799900AB9A86 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -426,17 +430,20 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Toucan-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.thesimplelab.Toucan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		740AC3FF1999799900AB9A86 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -444,10 +451,12 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Toucan-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = co.thesimplelab.Toucan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -466,6 +475,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "au.net.bunney.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -480,12 +490,14 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "au.net.bunney.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
 		C4D770E91C2BF2C800B15C64 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -501,14 +513,16 @@
 				PRODUCT_NAME = Toucan;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
 		C4D770EA1C2BF2C800B15C64 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
@@ -525,8 +539,9 @@
 				PRODUCT_NAME = Toucan;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};

--- a/ToucanPlayground.playground/section-1.swift
+++ b/ToucanPlayground.playground/section-1.swift
@@ -39,19 +39,19 @@ let octagonMask = UIImage(named: "OctagonMask.png")
 // ------------------------------------------------------------
 
 // Crop will resize to fit one dimension, then crop the other
-Toucan(image: portraitImage!).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Crop).image
+Toucan(image: portraitImage!).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.crop).image
 
 // Clip will resize so one dimension is equal to the size, the other shrunk down to retain aspect ratio
-Toucan(image: portraitImage!).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Clip).image
+Toucan(image: portraitImage!).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.clip).image
 
 // Scale will resize so the image fits exactly, altering the aspect ratio
-Toucan(image: portraitImage!).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Scale).image
+Toucan(image: portraitImage!).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.scale).image
 
 // ------------------------------------------------------------
 // Masking
 // ------------------------------------------------------------
 
-let landscapeCropped = Toucan(image: landscapeImage!).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.Crop).image
+let landscapeCropped = Toucan(image: landscapeImage!).resize(CGSize(width: 500, height: 500), fitMode: Toucan.Resize.FitMode.crop).image
 
 // We can mask with an ellipse!
 Toucan(image: landscapeImage!).maskWithEllipse().image
@@ -60,24 +60,24 @@ Toucan(image: landscapeImage!).maskWithEllipse().image
 Toucan(image: landscapeCropped).maskWithEllipse().image
 
 // Mask with borders too!
-Toucan(image: landscapeCropped).maskWithEllipse(borderWidth: 10, borderColor: UIColor.yellowColor()).image
+Toucan(image: landscapeCropped).maskWithEllipse(borderWidth: 10, borderColor: UIColor.yellow).image
 
 // Rounded Rects are all in style
 Toucan(image: landscapeCropped).maskWithRoundedRect(cornerRadius: 30).image
 
 // And can be fancy with borders
-Toucan(image: landscapeCropped).maskWithRoundedRect(cornerRadius: 30, borderWidth: 10, borderColor: UIColor.purpleColor()).image
+Toucan(image: landscapeCropped).maskWithRoundedRect(cornerRadius: 30, borderWidth: 10, borderColor: UIColor.purple).image
 
 // Masking with an custom image mask
 Toucan(image: landscapeCropped).maskWithImage(maskImage: octagonMask!).image
 
 //testing the path stuff
 let path = UIBezierPath()
-path.moveToPoint(CGPointMake(0, 50))
-path.addLineToPoint(CGPointMake(50, 0))
-path.addLineToPoint(CGPointMake(100, 50))
-path.addLineToPoint(CGPointMake(50, 100))
-path.closePath()
+path.move(to: CGPoint(x: 0, y: 50))
+path.addLine(to: CGPoint(x: 50, y: 0))
+path.addLine(to: CGPoint(x: 100, y: 50))
+path.addLine(to: CGPoint(x: 50, y: 100))
+path.close()
 Toucan(image: landscapeCropped).maskWithPath(path: path).image
 
 Toucan(image: landscapeCropped).maskWithPathClosure(path: {(rect) -> (UIBezierPath) in
@@ -90,6 +90,6 @@ Toucan(image: landscapeCropped).maskWithPathClosure(path: {(rect) -> (UIBezierPa
 // ------------------------------------------------------------
 
 // We can draw ontop of another image
-Toucan(image: portraitImage!).layerWithOverlayImage(octagonMask!, overlayFrame: CGRectMake(450, 400, 200, 200)).image
+Toucan(image: portraitImage!).layerWithOverlayImage(octagonMask!, overlayFrame: CGRect(x: 450, y: 400, width: 200, height: 200)).image
 
 

--- a/ToucanPlayground.playground/timeline.xctimeline
+++ b/ToucanPlayground.playground/timeline.xctimeline
@@ -3,12 +3,12 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=3555&amp;EndingColumnNumber=63&amp;EndingLineNumber=80&amp;StartingColumnNumber=1&amp;StartingLineNumber=80&amp;Timestamp=473560563.538163"
+         documentLocation = "#CharacterRangeLen=62&amp;CharacterRangeLoc=3533&amp;EndingColumnNumber=63&amp;EndingLineNumber=80&amp;StartingColumnNumber=1&amp;StartingLineNumber=80&amp;Timestamp=496083495.738634"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=158&amp;CharacterRangeLoc=3619&amp;EndingColumnNumber=9&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=82&amp;Timestamp=473560563.53841"
+         documentLocation = "#CharacterRangeLen=158&amp;CharacterRangeLoc=3597&amp;EndingColumnNumber=9&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=82&amp;Timestamp=496083495.738872"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>


### PR DESCRIPTION
Hey @gavinbunney!  Here's a Swift 3 migration which I made for [Nuke Toucan Plugin](https://github.com/kean/Nuke-Toucan-Plugin). 
- It compiles, it works, it leaves all of the public APIs intact
- Xcode has also automatically indented comments, hope you're ok with that
- Xcode has changes some project settings, I've also manually added `IPHONEOS_DEPLOYMENT_TARGET = 8.0;` and `APPLICATION_EXTENSION_API_ONLY = YES;`
- I couldn't set a base branch as a new `develop-swift-3` so you'll probably have to do it yourself if you merge

I understand that you'd probably want to migrate Toucan yourself, update to [Swift 3 API Design Guidelines](https://swift.org/blog/swift-3-api-design/) the way you want, etc. In that case just close the PR. I just hope to switch to the main repo soon.

Thanks for the library, it's great that it does just one thing! 👍
