### PR TITLE
Fix rotation crash #27

### DIFF
--- a/Source/Toucan.swift
+++ b/Source/Toucan.swift
@@ -544,7 +544,7 @@ public class Toucan : NSObject {
             
             let context : CGContext = CGContext(data: nil, width: contextWidth, height: contextHeight,
                                                 bitsPerComponent: image.cgImage!.bitsPerComponent,
-                                                bytesPerRow: image.cgImage!.bytesPerRow,
+                                                bytesPerRow: 0,
                                                 space: image.cgImage!.colorSpace!,
                                                 bitmapInfo: image.cgImage!.bitmapInfo.rawValue)!;
             


### PR DESCRIPTION
The rotation crash mentioned at https://github.com/gavinbunney/Toucan/issues/27 seems to be still there.

This patch is dead simple. It enables the automatic calculation of `bytesPerRow` available only when `data` is `nil`.
https://developer.apple.com/documentation/coregraphics/cgcontext/1455939-init

